### PR TITLE
Add extra safety to cside functions + fmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
+name = "odeir"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,14 +69,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serialization"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -70,7 +70,13 @@ renaming_overrides_prefixing = false
 
 
 [export.body]
-
+"RawVec" = """
+    ~RawVec<T>() {
+        if(!destructor(*this)) {
+            std::printf("Failed to free RawVec %p\\n", this);
+        }
+    }
+"""
 
 [export.mangle]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,2 @@
-#![feature(vec_into_raw_parts)]
-
-pub mod rustside;
 pub mod cside;
+pub mod rustside;


### PR DESCRIPTION
This change introduces return values for when a rust function panics. This way we can handle panics in c/c++ land without running into UB.

Also, this introduces a new `RawVec<T>` type to make FFI easier and safer. Thanks to cbindgen, it was a breeze.