### PR TITLE
Add extra safety to cside functions + fmt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,9 +9,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
+name = "libc"
+version = "0.2.140"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99227334921fae1a979cf0bfdfcc6b3e5ce376ef57e16fb6fb3ea2ed6095f80c"
+
+[[package]]
 name = "odeir"
 version = "0.1.0"
 dependencies = [
+ "libc",
  "serde",
  "serde_json",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,5 +8,6 @@ crate-type = ["staticlib"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+libc = "0.2.140"
 serde = { version = "1.0.147", features = ["derive"] }
 serde_json = "1.0.88"

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -21,7 +21,7 @@ include_version = false
 # namespace = "my_namespace"
 namespaces = []
 using_namespaces = []
-sys_includes = []
+sys_includes = ['stdexcept']
 includes = []
 no_includes = false
 after_includes = ""
@@ -70,10 +70,20 @@ renaming_overrides_prefixing = false
 
 
 [export.body]
-"RawVec" = """
-    ~RawVec<T>() {
-        if(!destructor(*this)) {
-            std::printf("Failed to free RawVec %p\\n", this);
+"BoxedSlice" = """
+    ~BoxedSlice<T>() {
+        if(!destructor(this)) {
+            std::printf("Failed to free BoxedSlice %p\\n", this);
+        }
+    }
+    size_t length() const {
+        return len;
+    }
+    const T& operator[](size_t idx) const {
+        if (idx < len) {
+            return ptr[idx];
+        } else {
+            throw std::out_of_range("Index out of bounds");
         }
     }
 """

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -70,7 +70,13 @@ renaming_overrides_prefixing = false
 
 
 [export.body]
-
+"RawVec" = """
+    ~RawVec<T>() {
+        if(!destructor(*this)) {
+            std::printf("Failed to free RawVec %p\\n", this);
+        }
+    }
+"""
 
 [export.mangle]
 

--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -71,7 +71,7 @@ renaming_overrides_prefixing = false
 
 [export.body]
 "BoxedSlice" = """
-    ~BoxedSlice<T>() {
+    ~BoxedSlice() {
         if(!destructor(this)) {
             std::printf("Failed to free BoxedSlice %p\\n", this);
         }

--- a/include/odeir.h
+++ b/include/odeir.h
@@ -20,7 +20,7 @@ struct BoxedSlice {
     const T *ptr;
     size_t len;
     int (*destructor)(const BoxedSlice*);
-    ~BoxedSlice<T>() {
+    ~BoxedSlice() {
         if(!destructor(this)) {
             std::printf("Failed to free BoxedSlice %p\n", this);
         }

--- a/include/odeir.h
+++ b/include/odeir.h
@@ -14,6 +14,18 @@ struct MetaData {
 
 using NodeId = uint32_t;
 
+template<typename T>
+struct RawVec {
+    const T *ptr;
+    size_t len;
+    int (*destructor)(RawVec);
+    ~RawVec<T>() {
+        if(!destructor(*this)) {
+            std::printf("Failed to free RawVec %p\n", this);
+        }
+    }
+};
+
 struct CNode {
     enum class Tag {
         Population,
@@ -30,8 +42,7 @@ struct CNode {
         NodeId id;
         const char *name;
         uint32_t operation;
-        const NodeId *inputs;
-        size_t input_count;
+        RawVec<NodeId> inputs;
     };
 
     Tag tag;
@@ -48,15 +59,13 @@ struct CConstant {
 
 struct CModel {
     MetaData meta_data;
-    const CNode *nodes;
-    const CConstant *constants;
-    size_t node_count;
-    size_t constant_count;
+    RawVec<CNode> nodes;
+    RawVec<CConstant> constants;
 };
 
 
 extern "C" {
 
-CModel model_from_cstring(const char *json_str);
+int model_from_cstring(const char *json_str, CModel *cmodel);
 
 } // extern "C"

--- a/src/cside.rs
+++ b/src/cside.rs
@@ -1,28 +1,41 @@
 use crate::rustside::{Constant, MetaData, Model, Node, NodeId};
 
-use std::{ffi::{c_char, c_int, CStr, CString}, panic::RefUnwindSafe};
+use std::{ffi::{c_char, c_int, CStr, CString}, panic::{RefUnwindSafe, UnwindSafe}};
 
 #[repr(C)]
-#[derive(Debug)]
-pub struct RawVec<T> {
-    pub ptr: *const T,
-    pub len: usize,
-    pub destructor: extern "C" fn(Self) -> c_int,
+pub struct BoxedSlice<T> {
+    ptr: *const T,
+    len: usize,
+    destructor: extern "C" fn(*const Self) -> c_int,
 }
 
-impl<T> RawVec<T> where T: RefUnwindSafe {
-    pub extern "C" fn destructor(self) -> c_int {
-        let result = std::panic::catch_unwind(move || {
+impl<T> std::fmt::Debug for BoxedSlice<T> {
+   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "RawVec<{}> {{ len: {}, ptr: {:p}}}", std::any::type_name::<T>(), self.len, self.ptr)
+    } 
+}
+
+impl<T> BoxedSlice<T> where T: RefUnwindSafe {
+    pub extern "C" fn destructor(this: *const Self) -> c_int {
+        catch_panic(move || {
+            let this = unsafe { &*this };
+            // If this is zero, there was no memory allocated.
+            if this.len == 0 {
+                return;
+            }
             unsafe {
-                let slice = std::ptr::slice_from_raw_parts_mut(self.ptr as *mut T, self.len);
+                let slice = std::ptr::slice_from_raw_parts_mut(this.ptr as *mut T, this.len);
                 std::mem::drop(Box::from_raw(slice));
             }
-        });
-        result_to_int(result)
+        })
     }
 }
 
-impl<T, U> From<Vec<T>> for RawVec<U>
+fn catch_panic(f: impl FnOnce() + UnwindSafe) -> c_int {
+    result_to_int(std::panic::catch_unwind(f))
+}
+
+impl<T, U> From<Vec<T>> for BoxedSlice<U>
 where
     T: Into<U>,
     U: RefUnwindSafe
@@ -41,8 +54,8 @@ where
 #[derive(Debug)]
 pub struct CModel {
     pub meta_data: MetaData,
-    pub nodes: RawVec<CNode>,
-    pub constants: RawVec<CConstant>,
+    pub nodes: BoxedSlice<CNode>,
+    pub constants: BoxedSlice<CConstant>,
 }
 
 #[repr(C)]
@@ -57,7 +70,7 @@ pub enum CNode {
         id: NodeId,
         name: *const c_char,
         operation: char,
-        inputs: RawVec<NodeId>,
+        inputs: BoxedSlice<NodeId>,
     },
 }
 
@@ -128,7 +141,7 @@ where
         .collect::<Vec<U>>()
         .into_boxed_slice();
     let data = Box::leak(data);
-    (data.as_ptr() as *mut _, data.len())
+    (data.as_mut_ptr(), data.len())
 }
 
 fn result_to_int<T, E>(result: Result<T, E>) -> c_int {
@@ -140,10 +153,10 @@ fn result_to_int<T, E>(result: Result<T, E>) -> c_int {
 
 #[no_mangle]
 pub unsafe extern "C" fn model_from_cstring(json_str: *const c_char, cmodel: *mut CModel) -> c_int {
-    let result = std::panic::catch_unwind(|| {
+    catch_panic(|| {
         let json_str = unsafe { CStr::from_ptr(json_str) };
         let model: Model = serde_json::from_str(json_str.to_str().unwrap()).unwrap();
-        *cmodel = model.into()
-    });
-    result_to_int(result)
+        cmodel.write(model.into())
+    })
 }
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,2 @@
-#![feature(vec_into_raw_parts)]
-
-pub mod rustside;
 pub mod cside;
+pub mod rustside;

--- a/tests/src/test_deserialization.cpp
+++ b/tests/src/test_deserialization.cpp
@@ -11,7 +11,9 @@ TEST_CASE( "a json should be deserializable into a CModel" ) {
 
     // When - the json is deserialized into a CModel
 
-    CModel model = model_from_cstring(fixtures_simple_json);
+    CModel model;
+
+    REQUIRE( model_from_cstring((const char *) fixtures_simple_json, &model) == 1 );
 
     // Then - the model should have the correct values
 
@@ -23,7 +25,7 @@ TEST_CASE( "a json should be deserializable into a CModel" ) {
 
     // Nodes -----------------------------------------------
     
-    REQUIRE( model.node_count == 3 );
+    REQUIRE( model.nodes.length() == 3 );
 
     // Node 0 ----------------------------------------------
 
@@ -46,13 +48,13 @@ TEST_CASE( "a json should be deserializable into a CModel" ) {
     REQUIRE_THAT( model.nodes[2].combinator.name, Equals("Pop1 + Pop2") );
     REQUIRE( model.nodes[2].combinator.operation == '+' );
 
-    REQUIRE( model.nodes[2].combinator.input_count == 2 );
+    REQUIRE( model.nodes[2].combinator.inputs.length() == 2 );
     REQUIRE( model.nodes[2].combinator.inputs[0] == 1 );
     REQUIRE( model.nodes[2].combinator.inputs[1] == 2 );
 
     // Constants ------------------------------------------
 
-    REQUIRE( model.constant_count == 4 );
+    REQUIRE( model.constants.length() == 4 );
 
     // Constant 0 -----------------------------------------
 


### PR DESCRIPTION
This change introduces return values for when a rust function panics. This way we can handle panics in c/c++ land without running into UB.

Also, this introduces a new `RawVec<T>` type to make FFI easier and safer. Thanks to cbindgen, it was a breeze.