### PR TITLE
Adicionar testes unitários a desserialização

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Run Tests
+name: FFI Tests
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,26 @@
+name: Run Tests
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          submodules: "true"
+
+      - name: Use Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+
+      - name: Build Tests
+        run: make -C tests build
+
+      - name: Run Tests
+        run: make -C tests run

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 /target
+*.diff
+tests/fixtures/*.h*
+tests/test
+tests/obj/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "tests/lib/catch2"]
+	path = tests/lib/catch2
+	url = https://github.com/syndelis/catch2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4217ad341ebadf8d8e724e264f13e593e0648f5b3e94b3896a5df283be015ecc"
 
 [[package]]
+name = "odeir"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,14 +69,6 @@ dependencies = [
  "itoa",
  "ryu",
  "serde",
-]
-
-[[package]]
-name = "serialization"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,49 @@
+CC=g++ -std=c++20
+CFLAGS=-fpermissive
+CFLAGS_LIBS=-c
+
+ODEIR_LIB=../target/debug/libodeir.a
+
+CATCH2_PATH=lib/catch2
+CATCH2_EXTRAS_PATH=$(CATCH2_PATH)/extras
+CATCH2_EXTRAS_SRC=$(wildcard $(CATCH2_EXTRAS_PATH)/*.cpp)
+
+INCLUDE_DIRS=-I./ -I../ -I../include/ -I$(CATCH2_EXTRAS_PATH)
+
+LINK_DIRS=
+LINKS=
+DEFINE=
+
+FIXTURES_DIR=fixtures
+FIXTURES_SRC=$(wildcard $(FIXTURES_DIR)/*.json)
+FIXTURES=$(foreach src,$(FIXTURES_SRC),$(FIXTURES_DIR)/$(notdir $(basename $(src))).h)
+
+OBJ_DIR=obj
+SRC=$(wildcard src/**.cpp) $(CATCH2_EXTRAS_SRC)
+OBJ=$(foreach src,$(SRC),$(OBJ_DIR)/$(notdir $(basename $(src))).o)
+EXE=test
+
+VPATH=src $(wildcard src/*) $(CATCH2_EXTRAS_PATH)
+
+run: all
+	./$(EXE)
+
+all: $(EXE)
+
+$(EXE): $(FIXTURES) $(ODEIR_LIB) $(OBJ_DIR) $(OBJ)
+	$(CC) $(CFLAGS) $(OBJ) $(ODEIR_LIB) -o $@ $(INCLUDE_DIRS) $(LINK_DIRS) $(LINKS) $(DEFINE)
+
+$(FIXTURES): $(FIXTURES_DIR)/%.h : $(FIXTURES_DIR)/%.json
+	xxd -i $< > $@
+
+$(ODEIR_LIB):
+	cargo build
+
+$(OBJ_DIR):
+	mkdir -p $@
+
+$(OBJ): $(OBJ_DIR)/%.o : %.cpp
+	$(CC) $(CFLAGS) $(CFLAGS_LIBS) $< -o $@ $(INCLUDE_DIRS) $(LINK_DIRS) $(LINKS) $(DEFINE)
+
+clean:
+	rm -rf $(OBJ_DIR) $(FIXTURES) $(EXE)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -25,10 +25,10 @@ EXE=test
 
 VPATH=src $(wildcard src/*) $(CATCH2_EXTRAS_PATH)
 
-run: all
+run: build
 	./$(EXE)
 
-all: $(EXE)
+build: $(EXE)
 
 $(EXE): $(FIXTURES) $(ODEIR_LIB) $(OBJ_DIR) $(OBJ)
 	$(CC) $(CFLAGS) $(OBJ) $(ODEIR_LIB) -o $@ $(INCLUDE_DIRS) $(LINK_DIRS) $(LINKS) $(DEFINE)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -37,7 +37,7 @@ $(FIXTURES): $(FIXTURES_DIR)/%.h : $(FIXTURES_DIR)/%.json
 	xxd -i $< > $@
 
 $(ODEIR_LIB):
-	cargo build
+	cargo +nightly build
 
 $(OBJ_DIR):
 	mkdir -p $@

--- a/tests/fixtures/simple.json
+++ b/tests/fixtures/simple.json
@@ -1,0 +1,46 @@
+{
+    "metaData": {
+        "startTime": 0,
+        "endTime": 10.50,
+        "deltaTime": 0.1
+    },
+    "nodes": [
+        {
+            "id": 1,
+            "name": "Population 1",
+            "related_constant_name": "Population 1_0"
+        },
+        {
+            "id": 2,
+            "name": "Population 2",
+            "related_constant_name": "Population 2_0"
+        },
+        {
+            "id": 30,
+            "name": "Pop1 + Pop2",
+            "operation": "+",
+            "inputs": [
+                1,
+                2
+            ]
+        }
+    ],
+    "constants": [
+        {
+            "name": "gravity",
+            "value": 9.81
+        },
+        {
+            "name": "Population 1_0",
+            "value": 100
+        },
+        {
+            "name": "Population 2_0",
+            "value": 200
+        },
+        {
+            "name": "a",
+            "value": 1.6
+        }
+    ]
+}

--- a/tests/src/test_deserialization.cpp
+++ b/tests/src/test_deserialization.cpp
@@ -1,0 +1,77 @@
+#include <catch_amalgamated.hpp>
+#include <odeir.h>
+
+using Catch::Matchers::Equals;
+
+TEST_CASE( "a json should be deserializable into a CModel" ) {
+
+    // Given - a json string, stored in simple_json, auto-generated from fixtures/simple.json
+
+    #include <fixtures/simple.h>
+
+    // When - the json is deserialized into a CModel
+
+    CModel model = model_from_cstring(fixtures_simple_json);
+
+    // Then - the model should have the correct values
+
+    // MetaData --------------------------------------------
+    
+    REQUIRE( model.meta_data.start_time == 0 );
+    REQUIRE( model.meta_data.end_time == 10.5 );
+    REQUIRE( model.meta_data.delta_time == 0.1 );
+
+    // Nodes -----------------------------------------------
+    
+    REQUIRE( model.node_count == 3 );
+
+    // Node 0 ----------------------------------------------
+
+    REQUIRE( model.nodes[0].tag == CNode::Tag::Population );
+    REQUIRE( model.nodes[0].population.id == 1 );
+    REQUIRE_THAT( model.nodes[0].population.name, Equals("Population 1") );
+    REQUIRE_THAT( model.nodes[0].population.related_constant_name, Equals("Population 1_0") );
+
+    // Node 1 ----------------------------------------------
+
+    REQUIRE( model.nodes[1].tag == CNode::Tag::Population );
+    REQUIRE( model.nodes[1].population.id == 2 );
+    REQUIRE_THAT( model.nodes[1].population.name, Equals("Population 2") );
+    REQUIRE_THAT( model.nodes[1].population.related_constant_name, Equals("Population 2_0") );
+
+    // Node 2 ----------------------------------------------
+
+    REQUIRE( model.nodes[2].tag == CNode::Tag::Combinator );
+    REQUIRE( model.nodes[2].combinator.id == 30 );
+    REQUIRE_THAT( model.nodes[2].combinator.name, Equals("Pop1 + Pop2") );
+    REQUIRE( model.nodes[2].combinator.operation == '+' );
+
+    REQUIRE( model.nodes[2].combinator.input_count == 2 );
+    REQUIRE( model.nodes[2].combinator.inputs[0] == 1 );
+    REQUIRE( model.nodes[2].combinator.inputs[1] == 2 );
+
+    // Constants ------------------------------------------
+
+    REQUIRE( model.constant_count == 4 );
+
+    // Constant 0 -----------------------------------------
+
+    REQUIRE_THAT( model.constants[0].name, Equals("gravity") );
+    REQUIRE( model.constants[0].value == 9.81 );
+
+    // Constant 1 -----------------------------------------
+
+    REQUIRE_THAT( model.constants[1].name, Equals("Population 1_0") );
+    REQUIRE( model.constants[1].value == 100 );
+
+    // Constant 2 -----------------------------------------
+
+    REQUIRE_THAT( model.constants[2].name, Equals("Population 2_0") );
+    REQUIRE( model.constants[2].value == 200 );
+
+    // Constant 3 -----------------------------------------
+
+    REQUIRE_THAT( model.constants[3].name, Equals("a") );
+    REQUIRE( model.constants[3].value == 1.6 );
+
+}


### PR DESCRIPTION
Resolves #5 

Adiciona testes unitários que podem ser executados com `make` no diretório `tests/`. Os testes utilizam o _framework_ [Catch2](https://github.com/catchorg/catch2) incluído em `tests/lib/`.

Fixtures podem ser adicionadas no diretório `tests/fixtures/` e utilizadas da seguinte forma:

```c
#include <fixtures/NOME_DA_FIXTURE.h>

// Em algum lugar do código

REQUIRE_THAT( fixtures_NOME_DA_FIXTURE, Equals("Conteúdo da fixture") );
```